### PR TITLE
Fix ControlCommands property name in LeftSideControl

### DIFF
--- a/Controls/LeftSideControl.cs
+++ b/Controls/LeftSideControl.cs
@@ -16,13 +16,13 @@ namespace GMT_2025.Controls
 {
     public class LeftSideControl : ContentControl
     {
-        public static readonly DependencyProperty ControlCommmandsProperty =
-            DependencyProperty.Register(nameof(ControlCommmands), typeof(IDictionary<string, ControlCommand>), typeof(LeftSideControl),
+        public static readonly DependencyProperty ControlCommandsProperty =
+            DependencyProperty.Register(nameof(ControlCommands), typeof(IDictionary<string, ControlCommand>), typeof(LeftSideControl),
                 new PropertyMetadata(null, OnItemsSourceChanged));
-        public IDictionary<string, ControlCommand> ControlCommmands
+        public IDictionary<string, ControlCommand> ControlCommands
         {
-            get => (IDictionary<string, ControlCommand>)GetValue(ControlCommmandsProperty);
-            set => SetValue(ControlCommmandsProperty, value);
+            get => (IDictionary<string, ControlCommand>)GetValue(ControlCommandsProperty);
+            set => SetValue(ControlCommandsProperty, value);
         }
         private static void OnItemsSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {


### PR DESCRIPTION
## Summary
- rename mis-spelled `ControlCommmandsProperty` and `ControlCommmands` to `ControlCommandsProperty` and `ControlCommands`
- update bindings and references accordingly

## Testing
- `dotnet build "GMT 2025.sln"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ab301cde083218589191ee333d800