### PR TITLE
Add ObservableDictionary event tests

### DIFF
--- a/GMT 2025.sln
+++ b/GMT 2025.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.10.35122.118
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GMT 2025", "GMT 2025.csproj", "{40C5E9CD-5A76-40C9-9773-90D56A3809EE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GMT.Tests", "GMT.Tests/GMT.Tests.csproj", "{6D661D5F-563B-4E8E-8C14-11AAB5E7E562}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -12,10 +14,14 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{40C5E9CD-5A76-40C9-9773-90D56A3809EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{40C5E9CD-5A76-40C9-9773-90D56A3809EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{40C5E9CD-5A76-40C9-9773-90D56A3809EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{40C5E9CD-5A76-40C9-9773-90D56A3809EE}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {40C5E9CD-5A76-40C9-9773-90D56A3809EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {40C5E9CD-5A76-40C9-9773-90D56A3809EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {40C5E9CD-5A76-40C9-9773-90D56A3809EE}.Release|Any CPU.Build.0 = Release|Any CPU
+                {6D661D5F-563B-4E8E-8C14-11AAB5E7E562}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {6D661D5F-563B-4E8E-8C14-11AAB5E7E562}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {6D661D5F-563B-4E8E-8C14-11AAB5E7E562}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {6D661D5F-563B-4E8E-8C14-11AAB5E7E562}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/GMT.Tests/GMT.Tests.csproj
+++ b/GMT.Tests/GMT.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../Extension/ObservableDictionary.cs" Link="ObservableDictionary.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+  </ItemGroup>
+</Project>

--- a/GMT.Tests/ObservableDictionaryTests.cs
+++ b/GMT.Tests/ObservableDictionaryTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using Xunit;
+
+public class ObservableDictionaryTests
+{
+    [Fact]
+    public void Add_RaisesCollectionAndPropertyChanged()
+    {
+        var dict = new ObservableDictionary<string, int>();
+        NotifyCollectionChangedEventArgs collectionArgs = null;
+        var propertyNames = new List<string>();
+        dict.CollectionChanged += (s, e) => collectionArgs = e;
+        dict.PropertyChanged += (s, e) => propertyNames.Add(e.PropertyName);
+
+        dict.Add("a", 1);
+
+        Assert.Equal(NotifyCollectionChangedAction.Add, collectionArgs?.Action);
+        Assert.Contains(nameof(dict.Count), propertyNames);
+        Assert.Contains(nameof(dict.Keys), propertyNames);
+        Assert.Contains(nameof(dict.Values), propertyNames);
+    }
+
+    [Fact]
+    public void Remove_RaisesCollectionAndPropertyChanged()
+    {
+        var dict = new ObservableDictionary<string, int>();
+        dict.Add("a", 1);
+
+        NotifyCollectionChangedEventArgs collectionArgs = null;
+        var propertyNames = new List<string>();
+        dict.CollectionChanged += (s, e) => collectionArgs = e;
+        dict.PropertyChanged += (s, e) => propertyNames.Add(e.PropertyName);
+
+        dict.Remove("a");
+
+        Assert.Equal(NotifyCollectionChangedAction.Remove, collectionArgs?.Action);
+        Assert.Contains(nameof(dict.Count), propertyNames);
+        Assert.Contains(nameof(dict.Keys), propertyNames);
+        Assert.Contains(nameof(dict.Values), propertyNames);
+    }
+
+    [Fact]
+    public void Clear_RaisesCollectionResetAndPropertyChangedCount()
+    {
+        var dict = new ObservableDictionary<string, int>();
+        dict.Add("a", 1);
+
+        NotifyCollectionChangedEventArgs collectionArgs = null;
+        var propertyNames = new List<string>();
+        dict.CollectionChanged += (s, e) => collectionArgs = e;
+        dict.PropertyChanged += (s, e) => propertyNames.Add(e.PropertyName);
+
+        dict.Clear();
+
+        Assert.Equal(NotifyCollectionChangedAction.Reset, collectionArgs?.Action);
+        Assert.Single(propertyNames);
+        Assert.Contains(nameof(dict.Count), propertyNames);
+    }
+
+    [Fact]
+    public void UpdatingExistingKey_RaisesReplaceAction()
+    {
+        var dict = new ObservableDictionary<string, int>();
+        NotifyCollectionChangedAction? secondAction = null;
+
+        dict.CollectionChanged += (s, e) => secondAction = e.Action;
+
+        dict["a"] = 1;
+        secondAction = null;
+        dict["a"] = 2;
+
+        Assert.Equal(NotifyCollectionChangedAction.Replace, secondAction);
+    }
+}


### PR DESCRIPTION
## Summary
- add xUnit test project for ObservableDictionary
- verify Add, Remove, Clear events trigger appropriate notifications
- ensure updating an existing key triggers Replace

## Testing
- `dotnet test GMT.Tests/GMT.Tests.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ab31a20848321b77936de5cdd0cb4