### PR TITLE
Add GitHub Actions workflow to build .NET Framework project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Restore NuGet packages
+        run: nuget restore "GMT 2025.sln"
+
+      - name: Build
+        run: msbuild "GMT 2025.sln" /p:Configuration=Release
+
+      - name: Run tests
+        run: dotnet test GMT.Tests/GMT.Tests.csproj --configuration Release
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: |
+            GMT*/bin/Release/*.exe


### PR DESCRIPTION
## Summary
- add workflow to build and test .NET Framework 4.8 project on Windows runner

## Testing
- `dotnet test GMT.Tests/GMT.Tests.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: The repository is not signed; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ab53d8edc83219205eca1ce5e8a49