### PR TITLE
Exclude test sources from main project

### DIFF
--- a/GMT 2025.csproj
+++ b/GMT 2025.csproj
@@ -9,6 +9,10 @@
 		<AssemblyName>GMT_2025</AssemblyName>
 	</PropertyGroup>
 
+        <ItemGroup>
+          <Compile Remove="GMT.Tests\**\*.cs" />
+        </ItemGroup>
+
 	<ItemGroup>
 	  <None Remove="Resources\favicon.ico" />
 	</ItemGroup>


### PR DESCRIPTION
## Summary
- prevent GMT.Tests source files from being compiled into the main application

## Testing
- `dotnet build 'GMT 2025.csproj'` *(fails: command not found)*
- Attempted to install dotnet SDK via apt, but repository access failed with 403 errors


------
https://chatgpt.com/codex/tasks/task_e_689ababd443c8321be7c54a9f8140ed7