### PR TITLE
fix: add missing UniformGrid namespace

### DIFF
--- a/Controls/MainContentUniformGrid.xaml.cs
+++ b/Controls/MainContentUniformGrid.xaml.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 
 namespace GMT_2025.Controls


### PR DESCRIPTION
## Summary
- add missing System.Windows.Controls.Primitives namespace to MainContentUniformGrid

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ad06ac4808321acfbd8ef539f2418