### PR TITLE
Use relative path for build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           name: build-output
           path: |
-            GMT*/GMT*/bin/Release/net48/*.exe
+            bin/Release/net48/*.exe


### PR DESCRIPTION
## Summary
- fix build workflow artifact upload path to match actual output location

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ad10b77e08321968017c96e3fabfb